### PR TITLE
(DM-2367) remove --email parameter from lsstswBuild.sh invocation

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -149,8 +149,7 @@ factory.addStep(ShellCommand(
          command=[BUILDBOT_SCRIPTS+"/lsstswBuild.sh",
              "--branch", Property("branches"),
              "--builder_name", Property("buildername"),
-             "--build_number", Property("buildnumber"),
-             "--email", Property("email")],
+             "--build_number", Property("buildnumber")],
          workdir="lsstsw", description="lsstsw Build", timeout=16200,
          ))
 


### PR DESCRIPTION
The --email parameter was a noop and was removed from lsstswBuild.sh by PR
https://github.com/lsst-sqre/buildbot-scripts/pull/1